### PR TITLE
refactor to only find_by(id) when a number is the identifier requested

### DIFF
--- a/app/controllers/annotot/annotations_controller.rb
+++ b/app/controllers/annotot/annotations_controller.rb
@@ -50,7 +50,9 @@ module Annotot
     private
 
     def set_annotation
-      @annotation = Annotation.find_by(id: CGI.unescape(params[:id])) || Annotation.find_by(uuid: CGI.unescape(params[:id]))
+      @annotation = Annotot::Annotation.retrieve_by_id_or_uuid(
+        CGI.unescape(params[:id])
+      )
       raise ActiveRecord::RecordNotFound unless @annotation.present?
     end
 

--- a/app/models/annotot/annotation.rb
+++ b/app/models/annotot/annotation.rb
@@ -4,5 +4,17 @@ module Annotot
     validates :canvas, presence: true
 
     serialize :data, JSON
+
+    ##
+    # Used to differentiate between a numeric id and a uuid. Rails will trim a
+    # uuid with leading numbers eg '123a'.to_i => 123
+    # @param [String] identifier
+    def self.retrieve_by_id_or_uuid(identifier)
+      if identifier =~ /\A\d+\z/
+        find_by(id: identifier)
+      else
+        find_by(uuid: identifier)
+      end
+    end
   end
 end

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -77,10 +77,17 @@ RSpec.describe Annotot::AnnotationsController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    it 'destroys the requested annotation' do
+    it 'destroys the requested annotation by uuid' do
       annotation = FactoryBot.create :annotation
       expect do
         delete :destroy, params: { format: :json, id: annotation.uuid }
+      end.to change(Annotot::Annotation, :count).by(-1)
+    end
+
+    it 'destroys the requested annotation by id' do
+      annotation = FactoryBot.create :annotation
+      expect do
+        delete :destroy, params: { format: :json, id: annotation.id }
       end.to change(Annotot::Annotation, :count).by(-1)
     end
 

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe Annotot::Annotation do
+  describe '.retrieve_by_id_or_uuid' do
+    it 'looks up a non numeric only identifier by uuid' do
+      expect(Annotot::Annotation).to receive(:find_by).with(uuid: '123ab')
+      expect(described_class.retrieve_by_id_or_uuid('123ab'))
+    end
+    it 'looks up a numeric only identifier by id' do
+      expect(Annotot::Annotation).to receive(:find_by).with(id: '123')
+      expect(described_class.retrieve_by_id_or_uuid('123'))
+    end
+  end
+end


### PR DESCRIPTION
Resolves an issue where a uuid that begins with numbers are "looked up" by id that is truncated.